### PR TITLE
Replace `ar` with `ar_archive_writer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["include", "binary", "bytes", "file"]
 [dependencies]
 include-blob-macros = { path = "include-blob-macros", version = "0.1.0" }
 object = { version = "0.31.0", default-features = false, features = ["write"] }
-ar = { version = "0.8.0", package = "sludge-ar-with-ranlib" }
+ar_archive_writer = "0.1.4"


### PR DESCRIPTION
Removes the `ranlib` dependency on macOS.